### PR TITLE
리턴타입 / sms인증 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,13 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	//sms
+	implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+	implementation 'net.nurigo:sdk:4.3.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/OndaProject/Onda/domain/sms/controller/MessageController.java
+++ b/src/main/java/OndaProject/Onda/domain/sms/controller/MessageController.java
@@ -18,20 +18,14 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class MessageController {
 
+
+
     private final MessageService messageService;
 
     @PostMapping("/send-verification")
     public CommonResponse<Boolean> sendVerificationSms(@RequestBody @Valid SmsRequest.PhoneNumber smsRequest){
 
         String phoneNumber = smsRequest.phoneNumber();
-
-        if(phoneNumber.isEmpty()){
-            throw new IllegalArgumentException("No Argument");
-        }
-
-        if (!phoneNumber.matches("^010\\d{8}$")) {
-            throw new IllegalArgumentException("유효하지 않은 휴대폰 번호 형식입니다.");
-        }
 
         messageService.sendVerifyCode(phoneNumber);
 

--- a/src/main/java/OndaProject/Onda/domain/sms/controller/MessageController.java
+++ b/src/main/java/OndaProject/Onda/domain/sms/controller/MessageController.java
@@ -1,0 +1,50 @@
+package OndaProject.Onda.domain.sms.controller;
+
+
+import OndaProject.Onda.domain.sms.dto.SmsRequest;
+import OndaProject.Onda.domain.sms.service.MessageService;
+import OndaProject.Onda.global.response.CommonResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/sms")
+@Slf4j
+public class MessageController {
+
+    private final MessageService messageService;
+
+    @PostMapping("/send-verification")
+    public CommonResponse<Boolean> sendVerificationSms(@RequestBody @Valid SmsRequest.PhoneNumber smsRequest){
+
+        String phoneNumber = smsRequest.phoneNumber();
+
+        if(phoneNumber.isEmpty()){
+            throw new IllegalArgumentException("No Argument");
+        }
+
+        if (!phoneNumber.matches("^010\\d{8}$")) {
+            throw new IllegalArgumentException("유효하지 않은 휴대폰 번호 형식입니다.");
+        }
+
+        messageService.sendVerifyCode(phoneNumber);
+
+        return CommonResponse.ok(true);
+
+
+    }
+
+    @PostMapping("/verify-code")
+    public CommonResponse<Boolean> verifyCode(@RequestBody SmsRequest.VerifyCode verifyCode){
+
+        boolean result = messageService.verifyCode(verifyCode.phoneNumber(),verifyCode.code());
+        return CommonResponse.ok(result);
+
+    }
+}

--- a/src/main/java/OndaProject/Onda/domain/sms/dto/SmsRequest.java
+++ b/src/main/java/OndaProject/Onda/domain/sms/dto/SmsRequest.java
@@ -1,0 +1,22 @@
+package OndaProject.Onda.domain.sms.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public class SmsRequest{
+
+        public record PhoneNumber(
+                @NotBlank
+                @Pattern(regexp = "^010\\d{8}$")
+                String phoneNumber
+        ){}
+
+        public record VerifyCode(
+                @NotBlank
+                String phoneNumber,
+                @NotBlank
+                String code
+        ){}
+
+}

--- a/src/main/java/OndaProject/Onda/domain/sms/dto/SmsRequest.java
+++ b/src/main/java/OndaProject/Onda/domain/sms/dto/SmsRequest.java
@@ -8,7 +8,7 @@ public class SmsRequest{
 
         public record PhoneNumber(
                 @NotBlank
-                @Pattern(regexp = "^010\\d{8}$")
+                @Pattern(regexp = "^010\\d{8}$", message = "유효하지 않은 휴대폰 번호 형식입니다.")
                 String phoneNumber
         ){}
 

--- a/src/main/java/OndaProject/Onda/domain/sms/service/MessageService.java
+++ b/src/main/java/OndaProject/Onda/domain/sms/service/MessageService.java
@@ -1,0 +1,112 @@
+package OndaProject.Onda.domain.sms.service;
+
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Slf4j
+public class MessageService {
+
+    /*
+    Pass로 변경시(개발자모드테스트종료) log에 핸드폰번호는 삭제
+     */
+
+
+    private DefaultMessageService messageService;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final String REDIS_KEY_PREFIX = "verify:";
+
+    @Value("${onda-sms.api.key}")
+    private String apiKey;
+
+    @Value("${onda-sms.api.secret}")
+    private String apiSecret;
+
+    @Value("${onda-sms.api.url}")
+    private String apiUrl;
+
+    @Value("${onda-sms.sender-number}")
+    private String smsSenderNumber;
+
+    public MessageService(StringRedisTemplate stringRedisTemplate) {
+        this.stringRedisTemplate = stringRedisTemplate;
+    }
+
+    @PostConstruct
+    public void init() {
+        this.messageService = NurigoApp.INSTANCE.initialize(apiKey, apiSecret, apiUrl);
+    }
+
+    public String generateVerificationCode() {
+
+        return String.format("%06d", new Random().nextInt(999999));
+    }
+
+    public void sendVerifyCode(String phoneNumber) {
+        String authCode = generateVerificationCode();
+        String message = "[Onda] 인증번호: " + authCode;
+
+        try {
+            log.info("SMS 인증번호 발송 시도: phoneNumber={}", phoneNumber);
+
+            sendSms(smsSenderNumber, phoneNumber, message);
+
+            String redisKey = REDIS_KEY_PREFIX + phoneNumber;
+            stringRedisTemplate.opsForValue().set(redisKey, authCode, 3, TimeUnit.MINUTES);
+
+            log.info("SMS 인증번호 발송 성공: phoneNumber={}", phoneNumber);
+
+        } catch (Exception e) {
+            log.error("SMS 인증번호 발송 실패: phoneNumber={}, error={}", phoneNumber, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+
+
+    // 단일 메시지 발송
+    public SingleMessageSentResponse sendSms(String from, String to, String text) {
+        Message message = new Message();
+        message.setFrom(from);
+        message.setTo(to);
+        message.setText(text);
+
+        return messageService.sendOne(new SingleMessageSendingRequest(message));
+    }
+
+
+    public boolean verifyCode(String phoneNumber, String inputCode) {
+
+        log.info("인증번호 검증 시도: phoneNumber={}, inputCode={}", phoneNumber, inputCode);
+
+        String redisKey = REDIS_KEY_PREFIX + phoneNumber;
+        String storedCode = stringRedisTemplate.opsForValue().get(redisKey);
+
+        if (storedCode == null) {
+            log.warn("Redis 에 저장된 인증번호 없음: phoneNumber={}", phoneNumber);
+            return false;
+        }
+
+        boolean isValid = inputCode.equals(storedCode);
+        if (isValid) {
+            stringRedisTemplate.delete(redisKey);
+            log.info("인증번호 검증 성공: phoneNumber={}", phoneNumber);
+        } else {
+            log.warn("인증번호 검증 실패: phoneNumber={}", phoneNumber);
+        }
+        return isValid;
+    }
+
+}

--- a/src/main/java/OndaProject/Onda/global/redis/RedisConfig.java
+++ b/src/main/java/OndaProject/Onda/global/redis/RedisConfig.java
@@ -1,0 +1,16 @@
+package OndaProject.Onda.global.redis;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+}

--- a/src/main/java/OndaProject/Onda/global/response/CommonResponse.java
+++ b/src/main/java/OndaProject/Onda/global/response/CommonResponse.java
@@ -1,0 +1,20 @@
+package OndaProject.Onda.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CommonResponse<T>(boolean success, T data, String message) {
+
+    public static <T> CommonResponse<T> ok(T data) {
+        return new CommonResponse<>(true, data, "success");
+    }
+
+    public static <T> CommonResponse<T> ok(T data, String message) {
+        return new CommonResponse<>(true, data, message);
+    }
+
+    public static <T> CommonResponse<T> fail(String message) {
+        return new CommonResponse<>(false, null, message);
+    }
+
+}


### PR DESCRIPTION

CommonResponse 
- 기본 API 응답 포맷 구현
- 성공 시: ok(data), ok( data ,customMessage) 지원
- 실패 시: fail() (현재 사용 계획 없음 삭제 될 수 있음)


SMS 인증 서비스
- COOL SMS SDK(net.nurigo.sdk) 연동
- 솔라피 서비스 통해 실제 SMS 발송
- 인증번호 6자리 랜덤 생성
- Redis TTL 3분으로 설정

주요 엔드포인트
- POST /send-verification - 인증번호 발송
- POST /verify - 인증번호 확인

### 참고사항
- application.yml에 API 키/시크릿 설정 필요 (노션 yml 문서)
- 실서비스 전환 시 발신번호 변경 필수