### PR TITLE
feat exception , swagger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 	//sms
 	implementation 'org.apache.httpcomponents:httpclient:4.5.13'
 	implementation 'net.nurigo:sdk:4.3.0'
+
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/OndaProject/Onda/domain/sms/api/MessageApi.java
+++ b/src/main/java/OndaProject/Onda/domain/sms/api/MessageApi.java
@@ -1,0 +1,70 @@
+package OndaProject.Onda.domain.sms.api;
+
+import OndaProject.Onda.domain.sms.dto.SmsRequest;
+import OndaProject.Onda.global.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+public interface MessageApi {
+
+    @Operation(summary = "인증번호 SMS 발송", description = "휴대폰 번호로 인증번호 SMS를 발송합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증번호 발송 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "성공", value = """
+                                    {
+                                        "code": "SUCCESS",
+                                        "message": "인증번호 발송 성공",
+                                        "data": true
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "SMS 발송 실패", value = """
+                                    {
+                                        "code": "SMS-001",
+                                        "message": "SMS 발송에 실패했습니다."
+                                    }
+                                    """)
+                    }))
+    })
+    CommonResponse<Boolean> sendVerificationSms(SmsRequest.PhoneNumber smsRequest);
+
+    @Operation(summary = "인증번호 검증", description = "입력한 인증번호를 검증합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "성공", value = """
+                                    {
+                                        "code": "SUCCESS",
+                                        "message": "요청이 성공적으로 처리되었습니다.",
+                                        "data": true
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "인증번호가 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "인증번호 없음", value = """
+                                    {
+                                        "code": "SMS-002",
+                                        "message": "인증번호가 존재하지 않습니다."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "인증번호 불일치",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "인증 실패", value = """
+                                    {
+                                        "code": "SMS-003",
+                                        "message": "인증번호가 일치하지 않습니다."
+                                    }
+                                    """)
+                    }))
+    })
+    CommonResponse<Boolean> verifyCode(SmsRequest.VerifyCode verifyCode);
+}
+

--- a/src/main/java/OndaProject/Onda/domain/sms/controller/MessageController.java
+++ b/src/main/java/OndaProject/Onda/domain/sms/controller/MessageController.java
@@ -1,6 +1,7 @@
 package OndaProject.Onda.domain.sms.controller;
 
 
+import OndaProject.Onda.domain.sms.api.MessageApi;
 import OndaProject.Onda.domain.sms.dto.SmsRequest;
 import OndaProject.Onda.domain.sms.service.MessageService;
 import OndaProject.Onda.global.response.CommonResponse;
@@ -16,9 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/sms")
 @Slf4j
-public class MessageController {
-
-
+public class MessageController implements MessageApi {
 
     private final MessageService messageService;
 
@@ -29,7 +28,7 @@ public class MessageController {
 
         messageService.sendVerifyCode(phoneNumber);
 
-        return CommonResponse.ok(true);
+        return CommonResponse.ok(true,"인증번호 발송 성공");
 
 
     }
@@ -37,8 +36,8 @@ public class MessageController {
     @PostMapping("/verify-code")
     public CommonResponse<Boolean> verifyCode(@RequestBody SmsRequest.VerifyCode verifyCode){
 
-        boolean result = messageService.verifyCode(verifyCode.phoneNumber(),verifyCode.code());
-        return CommonResponse.ok(result);
+        messageService.verifyCode(verifyCode.phoneNumber(),verifyCode.code());
+        return CommonResponse.ok(true);
 
     }
 }

--- a/src/main/java/OndaProject/Onda/domain/sms/service/MessageService.java
+++ b/src/main/java/OndaProject/Onda/domain/sms/service/MessageService.java
@@ -1,6 +1,8 @@
 package OndaProject.Onda.domain.sms.service;
 
 
+import OndaProject.Onda.global.exception.CustomException;
+import OndaProject.Onda.global.exception.ExceptionCode;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import net.nurigo.sdk.NurigoApp;
@@ -60,7 +62,6 @@ public class MessageService {
 
         try {
             log.info("SMS 인증번호 발송 시도: phoneNumber={}", phoneNumber);
-
             sendSms(smsSenderNumber, phoneNumber, message);
 
             String redisKey = REDIS_KEY_PREFIX + phoneNumber;
@@ -70,7 +71,7 @@ public class MessageService {
 
         } catch (Exception e) {
             log.error("SMS 인증번호 발송 실패: phoneNumber={}, error={}", phoneNumber, e.getMessage(), e);
-            throw e;
+            throw new CustomException(ExceptionCode.SMS_SEND_FAILED);
         }
     }
 
@@ -87,8 +88,7 @@ public class MessageService {
     }
 
 
-    public boolean verifyCode(String phoneNumber, String inputCode) {
-
+    public void verifyCode(String phoneNumber, String inputCode) {
         log.info("인증번호 검증 시도: phoneNumber={}, inputCode={}", phoneNumber, inputCode);
 
         String redisKey = REDIS_KEY_PREFIX + phoneNumber;
@@ -96,17 +96,16 @@ public class MessageService {
 
         if (storedCode == null) {
             log.warn("Redis 에 저장된 인증번호 없음: phoneNumber={}", phoneNumber);
-            return false;
+            throw new CustomException(ExceptionCode.VERIFICATION_CODE_NOT_FOUND);
         }
 
-        boolean isValid = inputCode.equals(storedCode);
-        if (isValid) {
-            stringRedisTemplate.delete(redisKey);
-            log.info("인증번호 검증 성공: phoneNumber={}", phoneNumber);
-        } else {
+        if (!inputCode.equals(storedCode)) {
             log.warn("인증번호 검증 실패: phoneNumber={}", phoneNumber);
+            throw new CustomException(ExceptionCode.VERIFICATION_CODE_MISMATCH);
         }
-        return isValid;
+
+        stringRedisTemplate.delete(redisKey);
+        log.info("인증번호 검증 성공: phoneNumber={}", phoneNumber);
     }
 
 }

--- a/src/main/java/OndaProject/Onda/global/exception/CustomException.java
+++ b/src/main/java/OndaProject/Onda/global/exception/CustomException.java
@@ -1,0 +1,17 @@
+package OndaProject.Onda.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ExceptionCode exceptionCode;
+
+    public CustomException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.exceptionCode = exceptionCode;
+    }
+
+    public int getHttpStatus() {
+        return this.exceptionCode.getStatus();
+    }
+}

--- a/src/main/java/OndaProject/Onda/global/exception/ErrorResponse.java
+++ b/src/main/java/OndaProject/Onda/global/exception/ErrorResponse.java
@@ -1,0 +1,25 @@
+package OndaProject.Onda.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorResponse {
+    private String code;
+    private String message;
+    private int status;
+
+    public static ErrorResponse from(CustomException exception) {
+        return new ErrorResponse(
+                exception.getExceptionCode().getCode(),
+                exception.getMessage(),
+                exception.getHttpStatus()
+        );
+    }
+
+
+}

--- a/src/main/java/OndaProject/Onda/global/exception/ExceptionCode.java
+++ b/src/main/java/OndaProject/Onda/global/exception/ExceptionCode.java
@@ -1,0 +1,36 @@
+package OndaProject.Onda.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+public enum ExceptionCode {
+
+    // member
+    MEMBER_NOT_FOUND("ACCOUNT-001","사용자를 찾을 수 없습니다.", NOT_FOUND),
+
+
+
+    //Sms
+    SMS_SEND_FAILED("SMS-001", "SMS 발송에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    VERIFICATION_CODE_NOT_FOUND("SMS-002", "인증번호가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    VERIFICATION_CODE_MISMATCH("SMS-003", "인증번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+
+    ExceptionCode(String code, String message, HttpStatus status) {
+        this.code = code;
+        this.message = message;
+        this.status = status;
+    }
+
+    public int getStatus() {
+        return status.value();
+    }
+}

--- a/src/main/java/OndaProject/Onda/global/exception/GlobalException.java
+++ b/src/main/java/OndaProject/Onda/global/exception/GlobalException.java
@@ -1,0 +1,29 @@
+package OndaProject.Onda.global.exception;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalException {
+
+
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleBaseException(CustomException exception) {
+        log.warn("[Custom Exception] message : {}", exception.getMessage());
+
+        return ResponseEntity.status(exception.getHttpStatus()).body(ErrorResponse.from(exception));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+        log.error("[Unknown Exception]", ex);
+        ErrorResponse response = new ErrorResponse("INTERNAL_SERVER_ERROR", "서버 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR.value());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+}

--- a/src/main/java/OndaProject/Onda/global/swagger/SwaggerConfig.java
+++ b/src/main/java/OndaProject/Onda/global/swagger/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package OndaProject.Onda.global.swagger;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Onda API 명세서")
+                        .description("Onda 서비스의 REST API 문서입니다.")
+                        .version("v1")
+                );
+    }
+
+
+}


### PR DESCRIPTION
Exception
- CustomException & Exception enum 구현
- 에러코드 추가후 기존 sms서비스 예외발생시 throw 추가

Swagger
- 기존의 도메인의 디렉토리에 api 디렉토리 추가해서 인터페이스생성
- 기존 컨트롤러에서 구현 

### 참고사항
- 스웨거 인터페이스 작성시에 json포맷형태까지 작성을해놓았는데 좀 과하다싶으면 빼도괜찮을거같아요! 의견알려주세요